### PR TITLE
Wrap Scaffold95 body with Expanded to provide bounded constraints

### DIFF
--- a/lib/src/dialog95.dart
+++ b/lib/src/dialog95.dart
@@ -22,21 +22,23 @@ Future<T?> showDialog95<T>({
           constraints: BoxConstraints(
             maxWidth: maxWidth,
           ),
-          child: Scaffold95(
-            title: title,
-            body: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-              child: Column(
-                children: <Widget>[
-                  _iconMessageRow(message),
-                  const SizedBox(height: 8),
-                  Button95(
-                    onTap: () {
-                      Navigator.of(context).pop(true);
-                    },
-                    child: const Text('OK'),
-                  ),
-                ],
+          child: IntrinsicHeight(
+            child: Scaffold95(
+              title: title,
+              body: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+                child: Column(
+                  children: <Widget>[
+                    _iconMessageRow(message),
+                    const SizedBox(height: 8),
+                    Button95(
+                      onTap: () {
+                        Navigator.of(context).pop(true);
+                      },
+                      child: const Text('OK'),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/src/scaffold95.dart
+++ b/lib/src/scaffold95.dart
@@ -36,7 +36,7 @@ class Scaffold95 extends StatelessWidget {
           const SizedBox(height: 4),
           if (toolbar != null) toolbar!,
           if (toolbar != null) const SizedBox(height: 4),
-          body,
+          Expanded(child: body),
         ],
       ),
     );


### PR DESCRIPTION
Resolves #27

**Problem**
Previously, `Scaffold95` placed body directly in a Column without giving it bounded constraints, which caused:
- Center widget didn't actually center its children
- Widgets using double.infinity (e.g.,  `SizedBox(width: double.infinity))` threw unbounded constraints errors

**Solution**
Wrapped body with `Expanded` in the `Column`'s children list:
```dart
// lib/src/scaffold95.dart
children: <Widget>[
  WindowHeader95(title: title, onClosePressed: onClosePressed),
  const SizedBox(height: 4),
  if (toolbar != null) toolbar!,
  if (toolbar != null) const SizedBox(height: 4),
  Expanded(child: body),  // Now receives bounded constraints
],
```

Additionally, wrapped `Scaffold95` with `IntrinsicHeight`  to prevent dialogs from expanding to fill the entire screen:

```dart
// lib/src/dialog95.dart
return Center(
  child: ConstrainedBox(
    constraints: BoxConstraints(maxWidth: maxWidth),
    child: IntrinsicHeight(
      child: Scaffold95(
          //...
      ),
    ),
  ),
);
```

This makes body fill the remaining space and receive proper constraints.

**Testing**
- [x] Center now centers widgets correctly
- [x] double.infinity dimensions work without errors
- [x]  Existing dialogs and examples continue to work